### PR TITLE
Publish crate github action initial

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     - name: Install stable toolchain
       uses: actions-rs/toolchain@v1
       with:
-      profile: minimal
-      toolchain: stable
-      override: true
+        profile: minimal
+        toolchain: stable
+        override: true
       
     - run: cargo publish --token ${CRATES_TOKEN} --manifest-path ./linux_details/
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,4 @@
-on:
-  push:
-    tags:
-      - '*'
-  workflow_dispatch:
+on: [workflow_dispatch]
 
   name: Publish
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,21 @@
 on: [workflow_dispatch]
 name: Publish
 
-  jobs:
-    publish:
-      name: Publish
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout sources
-          uses: actions/checkout@v2
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
 
-        - name: Install stable toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
-          
-        - run: cargo publish --token ${CRATES_TOKEN} --manifest-path ./linux_details/
-          env:
-            CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+      profile: minimal
+      toolchain: stable
+      override: true
+      
+    - run: cargo publish --token ${CRATES_TOKEN} --manifest-path ./linux_details/
+      env:
+      CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,4 @@ jobs:
       
     - run: cargo publish --token ${CRATES_TOKEN} --manifest-path ./linux_details/
       env:
-      CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
 on: [workflow_dispatch]
-
-  name: Publish
+name: Publish
 
   jobs:
     publish:


### PR DESCRIPTION
Initial implementation for github action.

Right now requires a manual trigger. Will change later to more automated trigger, but this is just for initial testing that everything work once the restructure is put into place.